### PR TITLE
Integrate ollama

### DIFF
--- a/r-gcmt/src/config.rs
+++ b/r-gcmt/src/config.rs
@@ -4,4 +4,5 @@ use serde::{ Deserialize, Serialize };
 pub struct Config {
     #[serde(rename="ticketNumber")]
     pub ticket_number: String,
+    pub model: String,
 }

--- a/r-gcmt/src/handle_ticket.rs
+++ b/r-gcmt/src/handle_ticket.rs
@@ -4,24 +4,29 @@ use std::fs::{ read_to_string };
 
 use crate::{ config::Config, read_env::read_env };
 
-fn read_json (json_path: &PathBuf, _debug: bool) -> Result<String> {
+pub fn read_json (json_path: &PathBuf, _debug: bool) -> Result<Config> {
     let json = read_to_string(json_path).with_context(|| format!("Error reading json_path '{}' to string", json_path.display()))?;
     
     let config: Config = serde_json::from_str(&json).with_context(|| format!("Error deserialising JSON"))?;
 
-    Ok(config.ticket_number)
+    Ok(config)
 }
 
 pub fn handle_ticket (json_path: &PathBuf, env_var_key: &str, debug: bool) -> Result<String> {
     if debug { println!("handle_ticket") };
     
     // Read value of ticket
-    let read_json = read_json(&json_path, debug);
-    let ticket = if let Ok(read_json_string) = read_json {
-        read_json_string
-    } else {
-        read_env(&env_var_key, debug).with_context(|| format!("Failed to read ticket from config.json and Shell Envs at handle_ticket. Has a ticket number been set anywhere?"))?
+    let read_json = match read_json(&json_path, debug) {
+        Ok(config) => config, 
+        Err(e) => {
+            if debug { println!("read_json failed with error: {}, attempting to read from ENVs", e)}
+            let config = Config {
+                ticket_number: read_env(&env_var_key, debug).with_context(|| format!("Failed to read ticket from config.json and Shell Envs at handle_ticket. Has a ticket number been set anywhere?"))?, 
+                model: String::new(),
+            };
+            config
+        }
     };
 
-    Ok(ticket)
+    Ok(read_json.ticket_number)
 }

--- a/r-gcmt/src/main.rs
+++ b/r-gcmt/src/main.rs
@@ -1,5 +1,5 @@
 use std::process::{ Command };
-use clap::Parser;
+use clap::{ Parser, Subcommand};
 use anyhow::{ Context, Result };
 use dirs::cache_dir;
 
@@ -11,42 +11,76 @@ use set_json::set_json;
 use handle_ticket::handle_ticket;
 
 #[derive(Parser)]
+#[command(subcommand_negates_reqs = true)]
 struct Cli {
-    message: String,
+    #[arg(required = true)]
+    message: Option<String>,
     #[arg( default_value(""))]
     ticket: String, 
     #[arg(long="set-env", short, action=clap::ArgAction::SetTrue, default_value_t=false)]
     set_config: bool,
     #[arg(long, short, action)]
     debug: bool,
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    SetModel {
+        model: String,
+    },
+    SetTicket {
+        ticket: String,
+    },
 }
 
 // Supported cases
 // CASE 1: gcmt "message" "ticket"
 // CASE 2: gcmt -s "message" "ticket"
 // CASE 3a || b: gcmt "message" + `export RGCMT_TICKET=1111` || -s "ticket"
+// CASE 4: gcmt 
 fn main() -> Result<()> {
-    let args = Cli::parse();
-    let env_var_key = format!("RGCMT_TICKET");
+    let cli = Cli::parse();
+    // Handle subcommands
+    match &cli.command {
+        // If set-model: Set model value into JSON, then return
+        Some(Commands::SetModel { model }) => {
+            println!("model: {}", model);
+            return Ok(())
+        },
+        // If set-ticket: Set ticket value into JSON, then return
+        Some(Commands::SetTicket { ticket }) => {
+            println!("ticket: {}", ticket);
+            return Ok(())
+        },
+        None => {}
+    };
+    // Handle unset message
+    let message = match &cli.message {
+        Some(message) => message.to_string(),
+        None => panic!("Message not set")
+    };
+    let env_var_key = "RGCMT_TICKET".to_string();
     // Define config.json_path
     let cache_dir_path = cache_dir()
         .with_context(|| format!("dirs::cache_dir() panicked"))?;
     let config_path = cache_dir_path.join(r"r-gcmt/config.json");
 
-    if args.debug { println!("set_env: {}, json_path: {}", args.set_config, config_path.display()) };
-    if args.set_config {
-        set_json(&args.ticket, &config_path, &env_var_key, args.debug)
+    if cli.debug { println!("set_env: {}, json_path: {}", cli.set_config, config_path.display()) };
+    if cli.set_config {
+        set_json(&cli.ticket, &config_path, &env_var_key, cli.debug)
             .with_context(|| format!("set_json failed"))?;
     }
 
-    let ticket = if !args.ticket.is_empty() {
-        args.ticket
+    let ticket = if !cli.ticket.is_empty() {
+        cli.ticket
     } else {
-        handle_ticket(&config_path, &env_var_key, args.debug)?
+        handle_ticket(&config_path, &env_var_key, cli.debug)?
     };
 
-    let commit_message = format!("{}: {}", ticket, args.message);
-    if args.debug {
+    let commit_message = format!("{}: {}", ticket, message);
+    if cli.debug {
         println!("Commit Message: '{}'", commit_message);
         println!("__________________");
     }

--- a/r-gcmt/src/main.rs
+++ b/r-gcmt/src/main.rs
@@ -1,19 +1,20 @@
-use std::process::{ Command };
+use std::{ process::Command, io };
 use clap::{ Parser, Subcommand};
 use anyhow::{ Context, Result };
 use dirs::cache_dir;
 
-mod set_json;
+mod set_ticket;
 mod handle_ticket;
 mod read_env;
 mod config;
-use set_json::set_json;
+use set_ticket::set_ticket;
 use handle_ticket::handle_ticket;
+
+use crate::{handle_ticket::read_json, set_ticket::write_json};
 
 #[derive(Parser)]
 #[command(subcommand_negates_reqs = true)]
 struct Cli {
-    #[arg(required = true)]
     message: Option<String>,
     #[arg( default_value(""))]
     ticket: String, 
@@ -41,17 +42,41 @@ enum Commands {
 // CASE 3a || b: gcmt "message" + `export RGCMT_TICKET=1111` || -s "ticket"
 // CASE 4: gcmt 
 fn main() -> Result<()> {
+    let env_var_key = "RGCMT_TICKET".to_string();
+    let ollama_prompt = String::from("Given the following git diff output, generate a concise Git commit message summarising the changes. The message should follow conventional commit style when appropriate. Keep the message short (max 50 characters) and imperative mood (e.g., Add feature, Fix bug). git diff: ");
+
     let cli = Cli::parse();
+    // Define config.json_path
+    let cache_dir_path = cache_dir()
+        .with_context(|| format!("dirs::cache_dir() panicked"))?;
+    let config_path = cache_dir_path.join(r"r-gcmt/config.json");
     // Handle subcommands
     match &cli.command {
         // If set-model: Set model value into JSON, then return
         Some(Commands::SetModel { model }) => {
-            println!("model: {}", model);
+            let model_list = Command::new("ollama")
+                .args(["show", model])
+                .output();
+            match model_list {
+                Err(e) => panic!("ollama list panicked with error: {}", e),
+                Ok(v) => {
+                    if !v.stdout.is_empty() {
+                        let output = String::from_utf8_lossy(&v.stdout).into_owned();
+                        if cli.debug { println!("ollama show output: {}", output) }
+                        write_json("model", model, &config_path, cli.debug)?;
+                    } else if !v.stderr.is_empty() {
+                        println!("ollama show panicked with error: {}", String::from_utf8_lossy(&v.stderr).into_owned());
+                        panic!("Provided model name does not appear in ollama list output. Please ensure the provided value is a valid model for ollama run and is already downloaded onto your system via either ollama run or pull"); 
+                    } else { panic!("stdout and stderr empty") };
+                    println!("model: {}", model);
+                },
+            }
             return Ok(())
         },
         // If set-ticket: Set ticket value into JSON, then return
         Some(Commands::SetTicket { ticket }) => {
             println!("ticket: {}", ticket);
+            set_ticket(ticket, &config_path, &env_var_key, cli.debug)?;
             return Ok(())
         },
         None => {}
@@ -59,18 +84,59 @@ fn main() -> Result<()> {
     // Handle unset message
     let message = match &cli.message {
         Some(message) => message.to_string(),
-        None => panic!("Message not set")
+        None => {
+            let diff = Command::new("git")
+                .args(["diff", "--cached"])
+                .output();
+            let diff_output = match diff {
+                Err(e) => { panic!("git diff failed with error: {}", e) },
+                Ok(v) => {
+                    let string_v = if !v.stdout.is_empty() {
+                        String::from_utf8_lossy(&v.stdout).into_owned()
+                    } else if !v.stderr.is_empty() {
+                        panic!("git diff failed with error: {}", String::from_utf8_lossy(&v.stderr).into_owned());  
+                    } else { panic!("stdout and stderr empty") };
+                    string_v
+                },
+            };
+            let model_name = read_json(&config_path, cli.debug).unwrap().model;
+            let prompt = format!("{} {}",&ollama_prompt, &diff_output);
+            println!("Message not provided. Attempting auto-generation of message via ollama...");
+            let ollama_output = Command::new("ollama")
+                .args(["run", &model_name, &prompt])
+                .output();
+            let commit_m = match ollama_output {
+                Err(e) => panic!("ollama run failed with error: {}", e),
+                Ok(v) => {
+                    let string_v = if !v.stdout.is_empty() {
+                        String::from_utf8_lossy(&v.stdout).into_owned()
+                    } else if !v.stderr.is_empty() {
+                        panic!("ollama run failed with error: {}", String::from_utf8_lossy(&v.stderr).into_owned());  
+                    } else { panic!("stdout and stderr empty") };
+                    string_v.trim().to_string()
+                }
+            };
+            let mut input = String::new();
+            println!("Generated commit message: [{}]", commit_m);
+            println!("Proceed to commit with this message? Input 'y' to proceed, or 'n' to exit this command.");
+            let io = io::stdin();
+            
+            loop {
+                io.read_line(&mut input)?;
+                if input.trim().eq("y") {
+                    break;
+                } else if input.trim().eq("n") {
+                    panic!("Generated commit message rejected. Process exiting. If auto-generated messages don't line up with your changes correctly, consider changing the processing model or manually inputting.")
+                } else { input.clear() }
+            }
+            commit_m
+        }
     };
-    let env_var_key = "RGCMT_TICKET".to_string();
-    // Define config.json_path
-    let cache_dir_path = cache_dir()
-        .with_context(|| format!("dirs::cache_dir() panicked"))?;
-    let config_path = cache_dir_path.join(r"r-gcmt/config.json");
 
     if cli.debug { println!("set_env: {}, json_path: {}", cli.set_config, config_path.display()) };
     if cli.set_config {
-        set_json(&cli.ticket, &config_path, &env_var_key, cli.debug)
-            .with_context(|| format!("set_json failed"))?;
+        set_ticket(&cli.ticket, &config_path, &env_var_key, cli.debug)
+            .with_context(|| format!("set_ticket failed"))?;
     }
 
     let ticket = if !cli.ticket.is_empty() {

--- a/r-gcmt/src/set_json.rs
+++ b/r-gcmt/src/set_json.rs
@@ -1,6 +1,52 @@
 use std::{fs::{ write, create_dir_all }, path::{ PathBuf }};
 use anyhow::{ Context, Result };
-use crate::{ config::Config, read_env::read_env };
+use crate::{ config::Config, read_env::read_env, handle_ticket::read_json };
+
+pub fn write_json (key: &str, value: &str, json_path: &PathBuf, debug: bool) -> Result<()> {
+    // Check if utility directory already exists, and create it if not
+    let json_dir_path: PathBuf = json_path
+        .components()
+        .take(json_path.components().count() - 1)
+        .collect();
+    if !json_dir_path.is_dir() {
+        create_dir_all(&json_dir_path).with_context(|| format!("create_dir_all failed"))?;
+        if debug { println!("create_dir_all for path: {} succeeded", &json_dir_path.display()) }
+    };
+    let json = match read_json(json_path, debug) {
+        Ok(config) => config, 
+        Err(e) => {
+            if debug { println!("read_json failed with error: {}", e)}
+            let new_config = Config {
+                ticket_number: String::new(), 
+                model: String::new()
+            };
+            new_config
+        }
+    };
+    let new_json = match key {
+        "ticket_number" => {
+            let new_config = Config {
+                ticket_number: String::from(value), 
+                model: String::from(&json.model),
+            };
+            new_config
+        }, 
+        "model" => {
+            let new_config = Config {
+                ticket_number: String::from(&json.ticket_number), 
+                model: String::from(value),
+            };
+            new_config
+        }, 
+        _ => { panic!("Invalid key provided. Provided key is not a valid key of type Config.")},
+    };
+    // Serialise json contents
+    let serialised = serde_json::to_string(&new_json).unwrap();
+    // Write to file
+    write(json_path, serialised)
+        .with_context(|| format!("fs::write panicked"))?;
+    Ok(())
+}
 
 pub fn set_json (ticket_arg: &str, json_path: &PathBuf, env_var_key:&str, debug: bool) -> Result<()> {
     if debug { println!("set_json") };
@@ -11,20 +57,6 @@ pub fn set_json (ticket_arg: &str, json_path: &PathBuf, env_var_key:&str, debug:
         println!("INFO: This command has been run with the --set-config flag while an exported RGCMT_TICKET variable is active in your current shell. This will cause your saved config to be continually overridden by the Env value. To avoid this behaviour, close this shell and open a new session.");
         read_env(env_var_key, debug).with_context(|| format!("read_env failed at set_json. Is a ticket number set anywhere?"))?
     };
-    // Check if utility directory already exists, and create it if not
-    let json_dir_path: PathBuf = json_path
-        .components()
-        .take(json_path.components().count() - 1)
-        .collect();
-    if !json_dir_path.is_dir() {
-        create_dir_all(&json_dir_path).with_context(|| format!("create_dir_all failed"))?;
-        if debug { println!("create_dir_all for path: {} succeeded", &json_dir_path.display()) }
-    };
-    // Serialise json contents
-    let new_config = Config { ticket_number: ticket, };
-    let serialised = serde_json::to_string(&new_config).unwrap();
-    // Write to file
-    write(json_path, serialised)
-        .with_context(|| format!("fs::write panicked"))?;
+    write_json("ticket_number", &ticket, json_path, debug)?;
     Ok(())
 }

--- a/r-gcmt/src/set_ticket.rs
+++ b/r-gcmt/src/set_ticket.rs
@@ -48,7 +48,7 @@ pub fn write_json (key: &str, value: &str, json_path: &PathBuf, debug: bool) -> 
     Ok(())
 }
 
-pub fn set_json (ticket_arg: &str, json_path: &PathBuf, env_var_key:&str, debug: bool) -> Result<()> {
+pub fn set_ticket (ticket_arg: &str, json_path: &PathBuf, env_var_key:&str, debug: bool) -> Result<()> {
     if debug { println!("set_json") };
     // if ticket_arg is "", attempt to read from env
     let ticket: String = if !ticket_arg.is_empty() {


### PR DESCRIPTION
- `set-json.rs` renamed to `set-ticket.rs`
- Refactors of existing util functions to return full Config struct
- Addition branchs in logic of `main.rs` to support auto-generation of commit messages via Ollama if message is not manually supplied